### PR TITLE
Fix customer ID behavior on new copies

### DIFF
--- a/on_edit.js
+++ b/on_edit.js
@@ -195,12 +195,12 @@ function setCustomerKeyOnEdit(range) {
     let newValues = {}
     if (customerValues["Customer First Name"] && customerValues["Customer Last Name"]) {
       let lastCustomerID = getDocProp("lastCustomerID_")
-      if (!Number.isFinite(lastCustomerID)) {
+      if (!Number.isFinite(lastCustomerID) || lastCustomerID === 0) {
         const sheet = range.getSheet()
         const idColumnPosition = getSheetHeaderNames(sheet).indexOf("Customer ID") + 1
         const idRange = sheet.getRange(1, idColumnPosition, sheet.getLastRow())
         let maxID = getMaxValueInRange(idRange)
-        lastCustomerID = Number.isFinite(maxID) ? maxID : 1
+        lastCustomerID = Number.isFinite(maxID) ? maxID : 0
       }
       let nextCustomerID = Math.ceil(lastCustomerID) + 1
       // There is no ID. Set one and update the lastCustomerID property

--- a/sheets.js
+++ b/sheets.js
@@ -507,6 +507,7 @@ function getRangeHeaderFormulas(range, {forceRefresh = false, headerRowPosition 
 function getMaxValueInRange(range) {
   try {
     let values = range.getValues().flat().filter(Number.isFinite)
+    if (!values.length) return null
     return values.reduce((a, b) => Math.max(a, b))
   } catch(e) { logError(e) }
 }


### PR DESCRIPTION
Fix #87:
- Decided against making `lastCustomerID_` a visible doc prop. Because the Document Properties sheet does not auto-refresh, and has no other regularly updating values, it's too easy for the value on the sheet to be inaccurate, and to cause potential bugs or misunderstandings.
- Went for simplest fix possible, which is to check for the max value of customer ID whenever the lastCustomerID_ is 0. This will happen on new sheets and copied sheets. If there are no customers yet, it remains on the default of 0. This keeps a full check of the sheet from running on every edit, except the first time. 