### PR TITLE
Make buildDocumentPropertiesFromSheet work as expected

### DIFF
--- a/build.js
+++ b/build.js
@@ -95,29 +95,33 @@ function buildNamedRange(ss, rangeName, rangeConfigObj) {
   }
 }
 
-// Document properties don't pass on to copied sheets.
-// This recreates the ones put into the properties sheet.
-function buildDocumentPropertiesFromSheet() {
+function buildDocumentPropertiesIfEmpty() {
   const ss = SpreadsheetApp.getActiveSpreadsheet()
   const propSheet = ss.getSheetByName("Document Properties")
   let docProps = PropertiesService.getDocumentProperties().getProperties()
   if (Object.keys(docProps).length === 0 && propSheet) {
-    let propsGrid = propSheet.getDataRange().getValues()
-    propsGrid.shift() // Remove the header row from the array
-    let defaultPropNames = Object.keys(defaultDocumentProperties)
-    let newProps = []
-    propsGrid.forEach(row => {
-      if (defaultPropNames.indexOf(row[0]) !== -1) {
-        let prop = {}
-        prop.name = row[0]
-        prop.value = coerceValue(row[1], defaultDocumentProperties[row[0]].type)
-        prop.description = row[2]
-        newProps.push(prop)
-      }
-    })
-    setDocProps(newProps)
-    updatePropertiesSheet()
+    buildDocumentPropertiesFromSheet()
   }
+}
+
+function buildDocumentPropertiesFromSheet() {
+  const ss = SpreadsheetApp.getActiveSpreadsheet()
+  const propSheet = ss.getSheetByName("Document Properties")
+  let propsGrid = propSheet.getDataRange().getValues()
+  propsGrid.shift() // Remove the header row from the array
+  let defaultPropNames = Object.keys(defaultDocumentProperties)
+  let newProps = []
+  propsGrid.forEach(row => {
+    if (defaultPropNames.indexOf(row[0]) !== -1) {
+      let prop = {}
+      prop.name = row[0]
+      prop.value = coerceValue(row[1], defaultDocumentProperties[row[0]].type)
+      prop.description = row[2]
+      newProps.push(prop)
+    }
+  })
+  setDocProps(newProps)
+  updatePropertiesSheet()
 }
 
 // If there are any default document properties that are missing from the actual

--- a/on_open.js
+++ b/on_open.js
@@ -4,7 +4,7 @@ function onOpen(e) {
     buildMenus()
   } catch(e) { logError(e) }
   try {
-    buildDocumentPropertiesFromSheet()
+    buildDocumentPropertiesIfEmpty()
     buildDocumentPropertiesFromDefaults()
     purgeOldDocumentProperties()
   } catch(e) { logError(e) }

--- a/properties.js
+++ b/properties.js
@@ -261,38 +261,3 @@ function deleteDeprecatedProps() {
     logError(e)    
   }
 }
-
-function testTypes() {
-//  deleteDocProp("tripReviewRequiredFields")
-  repairProps()
-//  log(PropertiesService.getDocumentProperties().getProperty("tripReviewRequiredFields"))
-//  setDocProp("testArray",[1,2,3])
-//  setDocProp("testBigInt",BigInt(123))
-//  setDocProp("testBool", true)
-//  setDocProp("testBoolFalse", false)
-//  setDocProp("testDate",new Date())
-//  setDocProp("testMap",new Map([[1,"yes"],[2,"no"]]))
-//  setDocProp("testNull",null)
-//  setDocProp("testNumber",3.1415)
-//  setDocProp("testObject",{1:2,3:4,5:"six","seven":8})
-//  setDocProp("testSet",new Set([1,2,3]))
-//  setDocProp("testString","Test!")
-//  setDocProp("testSet",new Set([1,2,3]))
-//  setDocProp("testUndefined",undefined)
-}
-
-function cleanUpTestTypes() {
-//  deleteDocProp("testArray")
-//  deleteDocProp("testBigInt")
-//  deleteDocProp("testBool")
-//  deleteDocProp("testBoolFalse")
-//  deleteDocProp("testDate")
-//  deleteDocProp("testMap")
-//  deleteDocProp("testNull")
-//  deleteDocProp("testNumber")
-//  deleteDocProp("testObject")
-//  deleteDocProp("testSet")
-//  deleteDocProp("testString")
-//  deleteDocProp("testSet")
-//  deleteDocProp("testUndefined")
-}


### PR DESCRIPTION
Previous behavior of `buildDocumentPropertiesFromSheet()` only updated the docProps if they were empty, which prevented this function from running during new install setup and actually setting the new docProps. New function `buildDocumentPropertiesIfEmpty()` now has the old behavior, and still runs `onOpen()` 