### PR TITLE
Add fixFrozenRows

### DIFF
--- a/build.js
+++ b/build.js
@@ -559,6 +559,7 @@ function repairSheets() {
   fixSheetNames()
   fixNumberFormatting()
   fixDataValidation()
+  fixFrozenRows()
 }
 
 /**
@@ -830,6 +831,20 @@ function fixAllHeaderNames() {
     const range = getFullRow(sheet.getRange("A1"))
     fixHeaderNames(range)
   })
+}
+
+/**
+ * Ensures every configured sheet with a header row has exactly one frozen row.
+ * Called by `repairSheets()` and `onOpen()`.
+ */
+function fixFrozenRows() {
+  try {
+    const ss = SpreadsheetApp.getActiveSpreadsheet()
+    getConfiguredSheetsWithHeaders().forEach(sheetName => {
+      const sheet = ss.getSheetByName(sheetName)
+      if (sheet && sheet.getFrozenRows() !== 1) sheet.setFrozenRows(1)
+    })
+  } catch(e) { logError(e) }
 }
 
 /**

--- a/on_open.js
+++ b/on_open.js
@@ -37,6 +37,9 @@ function onOpen(e) {
   try {
     buildNamedRanges()
   } catch(e) { logError(e) }
+  try {
+    fixFrozenRows()
+  } catch(e) { logError(e) }
   checkTimezone()
   log("onOpen duration:",(new Date()) - startTime)
 }


### PR DESCRIPTION
Runs fixFrozenRows onOpen and during repairSheets, closes #120 

@keviniano since frozen row issues do not come up frequently, I've set this up to only run onOpen or when running the repairSheets function. It would be trivial to also have a check run onEdit, but I was worried about adding even more overhead to that call. Let me know what you think, and if you'd prefer that we also run this onEdit. 